### PR TITLE
v2.2.0 - Build 42 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zomboid_rcon: Python RCON for Project Zomboid Servers
 
-### Version: 2.1.0
+### Version: 2.2.0
 
 zomboid_rcon enables you to easily communicate with your Project Zomboid servers via RCON. With zomboid_rcon, you can send commands to your server, manage players, and more, all from within your Python script.
 
@@ -49,27 +49,33 @@ This example prints a list of all players currently connected to the server.
 
 zomboid_rcon provides built-in methods for the available RCON commands within Project Zomboid.
 
-These methods were curated from the list of commands listed here: [https://pzwiki.net/w/index.php?oldid=1361361](https://pzwiki.net/w/index.php?oldid=1361361)
+These methods are aligned with the Project Zomboid Build 42.20.2 command list:
+[https://pzwiki.net/wiki/Admin_commands](https://pzwiki.net/wiki/Admin_commands).
 
 ## General Commands
 
 - `additem("user", "item")` : Gives a player an item. Items can be found on the PZ wiki: https://pzwiki.net/wiki/Items
 - `additem("user", "item", count)` : As above, with an optional item count.
-- `addvehicle("vehiclescript", "user")` : Spawns a vehicle near a player.
+- `addkey("user", key_id)` : Gives a key to a player.
+- `addkey("user", key_id, "name")` : Gives a named key to a player.
+- `addvehicle("vehiclescript", "target")` : Spawns a vehicle near a player or at `x,y,z`.
 - `addxp("user", "perk", xp)` : Gives XP to a player.
 - `alarm()` : Sounds a building alarm at the admin's position. Must be in a room.
 - `changeoption("option", "newOption")` : Changes a server option.
 - `chopper()` : Places a helicopter event on a random player.
 - `changepwd("pwd", "newPwd")` : Changes your password.
-- `clear()` : Clears the server console.
 - `createhorde(count)` : Spawns a horde near you.
 - `createhorde(count, "username")` : Spawns a horde near a specific player.
+- `createhorde2(*args)` : Runs the game's currently undocumented `createhorde2` command.
 - `godmode("user")` : Makes a player invincible (default: true).
 - `godmode("user", False)` : Removes invincibility from a player.
+- `godmodeplayer("user", value)` : Changes god mode for another player.
 - `gunshot()` : Places a gunshot sound on a random player.
-- `help()` : Brings up the help menu. (Lists native RCON commands. For all zomboid_rcon commands, refer to this list)
+- `help()` : Lists native server commands.
+- `help("command")` : Shows native help for a specific command.
 - `invisible("user")` : Makes a player invisible to zombies (default: true).
 - `invisible("user", False)` : Makes a player visible to zombies again.
+- `invisibleplayer("user", value)` : Changes invisibility for another player.
 - `lightning()` : Triggers a lightning strike on a random player.
 - `lightning("user")` : Triggers a lightning strike on a specific player.
 - `log("type", "level")` : Sets the log level for a log type.
@@ -79,7 +85,6 @@ These methods were curated from the list of commands listed here: [https://pzwik
 - `releasesafehouse()` : Releases a safehouse you own.
 - `reloadlua("filename")` : Reload a lua script on the server.
 - `reloadoptions()` : Reloads server options.
-- `replay("user", [-record | -play | -stop], "filename")` : Records and plays a replay for a moving player.
 - `save()` : Saves the current world.
 - `sendpulse()` : Toggles sending server performance info to the client.
 - `showoptions()` : Shows a list of current server options and values.
@@ -93,6 +98,7 @@ These methods were curated from the list of commands listed here: [https://pzwik
 - `stopweather()` : Stops all weather on the server.
 - `teleport("user")` : Teleports yourself to a player.
 - `teleport("user", "toUser")` : Teleports one player to another.
+- `teleportplayer("user", "toUser")` : Teleports one player to another using the Build 42-specific command.
 - `teleportto(x, y, z)` : Teleports to certain coordinates.
 - `thunder()` : Triggers a thunder event on a random player.
 - `thunder("user")` : Triggers a thunder event on a specific player.
@@ -100,11 +106,15 @@ These methods were curated from the list of commands listed here: [https://pzwik
 ## Moderation Commands
 
 - `addalltowhitelist()` : Adds all current users connected with a password to the whitelist.
+- `addsteamid("SteamID")` : Adds a Steam ID to the server's allowed list.
+- `addtosafehouse(*args)` : Runs the game's currently undocumented `addtosafehouse` command.
 - `adduser("user", "pwd")` : Adds a new user to the whitelist.
 - `addusertowhitelist("user")` : Adds a single user connected with a password to the whitelist.
 - `removeuserfromwhitelist("user")` : Removes a single user from the whitelist.
 - `banid("SteamID")` : Bans a Steam ID.
+- `banip("IP")` : Bans an IP address.
 - `unbanid("SteamID")` : Unbans a Steam ID.
+- `unbanip("IP")` : Unbans an IP address.
 - `banuser("user")` : Bans a user.
 - `banuser("user", ip=True)` : Bans a user and their IP address.
 - `banuser("user", reason="reason")` : Bans a user with a reason.
@@ -114,10 +124,30 @@ These methods were curated from the list of commands listed here: [https://pzwik
 - `grantadmin("user")` : Gives admin rights to a user.
 - `removeadmin("user")` : Removes admin rights from a user.
 - `kickuser("user")` : Kicks a user from the server.
+- `kickuser("user", reason="reason")` : Kicks a user with a reason.
+- `kickfromsafehouse(*args)` : Runs the game's currently undocumented `kickfromsafehouse` command.
+- `list(*args)` : Runs the game's currently undocumented `list` command.
 - `players()` : Lists all connected players.
+- `reloadalllua()` : Reloads all Lua scripts.
+- `remove(*args)` : Runs the game's currently undocumented `remove` command.
+- `removeitem("module.item", count)` : Removes items from the command issuer; zero removes all of that type.
+- `removemapsymbolsforuser("user")` : Removes all shared map symbols for a user.
+- `removesteamid("SteamID")` : Removes a Steam ID from the server's allowed list.
+- `removezombies(*args)` : Runs the game's currently undocumented `removezombies` command.
 - `servermsg("message")` : Broadcast a message to all players. (Spaces are replaced with underscores for compatibility)
-- `setaccesslevel("user", [admin | moderator | overseer | gm | observer])` : Set the access/permission level of a player.
+- `setaccesslevel("user", [user | priority | observer | gm | moderator | admin])` : Sets a player's Build 42 access level.
+- `setpassword("user", "newPassword")` : Changes a user's password.
 - `voiceban("user", [-true | -false])` : Ban a user from using the voice feature.
+- `worldgen([start | recheck | stop | status])` : Controls Build 42's full world generator.
+
+The Build 42 commands whose syntax is still undocumented accept positional string
+arguments unchanged, so they remain usable as their in-game help is completed.
+
+## Build 41 compatibility
+
+Build 42 removed `replay` and no longer lists `clear`. Their methods remain available
+for Build 41 servers as `replay("user", "-record|-play|-stop", "filename")` and
+`clear()`, but emit `UserWarning` because Build 42 may reject them.
 
 ## Command not listed?
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,51 @@
+# Changelog
+
+## 2.2.0 - 2026-09-07
+
+_Build 42 support_
+
+### Added
+
+- Full support for the admin and RCON commands documented for Project Zomboid Build 42.20.2
+- New command methods for key management, Steam ID allowlisting, IP bans, player-specific admin actions, Lua reloading, item removal, map symbol removal, password changes, and world generation
+- Passthrough methods for Build 42 commands whose arguments are not yet documented by Project Zomboid
+- Optional command-specific help with `help("command")`
+- Optional kick reasons with `kickuser("user", reason="reason")`
+
+### Changed
+
+- Updated `addvehicle()` to support either a player name or coordinates as its target
+- Updated `setaccesslevel()` documentation with the Build 42 access levels
+- Updated the command reference and test coverage for Build 42
+
+### Deprecated
+
+- `replay()` was removed from Project Zomboid Build 42 and now emits a warning while remaining available for Build 41 servers
+- `clear()` is no longer listed as a Build 42 command and now emits a warning while remaining available for Build 41 servers
+
+## 2.1.0 - 2026-06-12
+
+First contribution by [ashy-ls](https://github.com/ashy-ls)
+
+### Added
+
+- Ability to test that RCON connections are successful with pings in [#13](https://github.com/jmwhitworth/zomboid_rcon/pull/13)
+
+## 2.0.0 - 2026-06-04
+
+_Build 41 support_
+
+### Added
+
+- Missing build 41 commands, bringing us to full support for build 41
+- Better exception handling
+- Additional test coverage
+- Support for Windows-based systems
+
+### Removed
+
+- `timeout_decorator` dependency, meaning Windows systems are now supported.
+
+## 1.0.0 - 2023-07-23
+
+_First full release_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zomboid_rcon"
-version = "2.1.0"
+version = "2.2.0"
 description = "Python class for interacting with Project Zomboid servers using RCON"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_ZomboidRcon.py
+++ b/tests/test_ZomboidRcon.py
@@ -51,6 +51,28 @@ class ZomboidRcon_test(unittest.TestCase):
         self.pz.additem("user1", "Base.Axe", 5)
         self.pz.command.assert_called_once_with("additem", "user1", "Base.Axe", "5")
 
+    def test_addkey_without_name(self):
+        self.pz.addkey("user1", 7295)
+        self.pz.command.assert_called_once_with("addkey", "user1", "7295")
+
+    def test_addkey_with_name(self):
+        self.pz.addkey("user1", 7295, "Gift Key")
+        self.pz.command.assert_called_once_with(
+            "addkey", "user1", "7295", "Gift Key"
+        )
+
+    def test_addsteamid(self):
+        self.pz.addsteamid("76561198000000000")
+        self.pz.command.assert_called_once_with(
+            "addSteamID", "76561198000000000"
+        )
+
+    def test_addtosafehouse_passes_undocumented_arguments(self):
+        self.pz.addtosafehouse("user1", "safehouse")
+        self.pz.command.assert_called_once_with(
+            "addtosafehouse", "user1", "safehouse"
+        )
+
     def test_addvehicle(self):
         self.pz.addvehicle("Base.VanSeats", "user1")
         self.pz.command.assert_called_once_with("addvehicle", "Base.VanSeats", "user1")
@@ -60,8 +82,13 @@ class ZomboidRcon_test(unittest.TestCase):
         self.pz.command.assert_called_once_with("addxp", "user1", "Strength=100")
 
     def test_clear(self):
-        self.pz.clear()
+        with self.assertWarns(UserWarning):
+            self.pz.clear()
         self.pz.command.assert_called_once_with("clear")
+
+    def test_createhorde2_passes_undocumented_arguments(self):
+        self.pz.createhorde2("10", "user1")
+        self.pz.command.assert_called_once_with("createhorde2", "10", "user1")
 
     def test_createhorde_without_user(self):
         self.pz.createhorde(50)
@@ -86,6 +113,22 @@ class ZomboidRcon_test(unittest.TestCase):
     def test_invisible_false(self):
         self.pz.invisible("user1", False)
         self.pz.command.assert_called_once_with("invisible", "user1", "-false")
+
+    def test_godmodeplayer(self):
+        self.pz.godmodeplayer("user1", False)
+        self.pz.command.assert_called_once_with(
+            "godmodeplayer", "user1", "-false"
+        )
+
+    def test_help_for_command(self):
+        self.pz.help("worldgen")
+        self.pz.command.assert_called_once_with("help", "worldgen")
+
+    def test_invisibleplayer(self):
+        self.pz.invisibleplayer("user1")
+        self.pz.command.assert_called_once_with(
+            "invisibleplayer", "user1", "-true"
+        )
 
     def test_lightning_without_user(self):
         self.pz.lightning()
@@ -143,6 +186,12 @@ class ZomboidRcon_test(unittest.TestCase):
         self.pz.teleport("user1", "user2")
         self.pz.command.assert_called_once_with("teleport", "user1", "user2")
 
+    def test_teleportplayer(self):
+        self.pz.teleportplayer("user1", "user2")
+        self.pz.command.assert_called_once_with(
+            "teleportplayer", "user1", "user2"
+        )
+
     def test_teleportto_formats_coordinates(self):
         self.pz.teleportto(100, 200, 0)
         self.pz.command.assert_called_once_with("teleportto", "100,200,0")
@@ -162,6 +211,13 @@ class ZomboidRcon_test(unittest.TestCase):
     def test_servermsg_strips_leading_trailing_whitespace(self):
         self.pz.servermsg("  Hello  ")
         self.pz.command.assert_called_once_with("servermsg", "Hello")
+
+    def test_replay_warns_that_build_42_removed_it(self):
+        with self.assertWarns(UserWarning):
+            self.pz.replay("user1", "-record", "test.bin")
+        self.pz.command.assert_called_once_with(
+            "replay", "user1", "-record", "test.bin"
+        )
 
     # --- Moderation commands ---
 
@@ -185,9 +241,31 @@ class ZomboidRcon_test(unittest.TestCase):
         self.pz.unbanuser("badguy")
         self.pz.command.assert_called_once_with("unbanuser", "badguy")
 
+    def test_banip(self):
+        self.pz.banip("192.0.2.1")
+        self.pz.command.assert_called_once_with("banip", "192.0.2.1")
+
+    def test_unbanip(self):
+        self.pz.unbanip("192.0.2.1")
+        self.pz.command.assert_called_once_with("unbanip", "192.0.2.1")
+
     def test_kickuser(self):
         self.pz.kickuser("someuser")
         self.pz.command.assert_called_once_with("kickuser", "someuser")
+
+    def test_kickuser_with_reason(self):
+        self.pz.kickuser("someuser", reason="spawn kill")
+        self.pz.command.assert_called_once_with(
+            "kickuser", "someuser", "-r", "spawn kill"
+        )
+
+    def test_kickfromsafehouse_passes_undocumented_arguments(self):
+        self.pz.kickfromsafehouse("someuser")
+        self.pz.command.assert_called_once_with("kickfromsafehouse", "someuser")
+
+    def test_list_passes_undocumented_arguments(self):
+        self.pz.list("players")
+        self.pz.command.assert_called_once_with("list", "players")
 
     def test_grantadmin(self):
         self.pz.grantadmin("someuser")
@@ -204,3 +282,41 @@ class ZomboidRcon_test(unittest.TestCase):
     def test_adduser(self):
         self.pz.adduser("newuser", "password123")
         self.pz.command.assert_called_once_with("adduser", "newuser", "password123")
+
+    def test_reloadalllua(self):
+        self.pz.reloadalllua()
+        self.pz.command.assert_called_once_with("reloadalllua")
+
+    def test_remove_passes_undocumented_arguments(self):
+        self.pz.remove("object")
+        self.pz.command.assert_called_once_with("remove", "object")
+
+    def test_removeitem(self):
+        self.pz.removeitem("Base.Axe", 5)
+        self.pz.command.assert_called_once_with("removeitem", "Base.Axe", "5")
+
+    def test_removemapsymbolsforuser(self):
+        self.pz.removemapsymbolsforuser("user1")
+        self.pz.command.assert_called_once_with(
+            "removemapsymbolsforuser", "user1"
+        )
+
+    def test_removesteamid(self):
+        self.pz.removesteamid("76561198000000000")
+        self.pz.command.assert_called_once_with(
+            "removeSteamID", "76561198000000000"
+        )
+
+    def test_removezombies_passes_undocumented_arguments(self):
+        self.pz.removezombies("user1")
+        self.pz.command.assert_called_once_with("removezombies", "user1")
+
+    def test_setpassword(self):
+        self.pz.setpassword("user1", "newpassword")
+        self.pz.command.assert_called_once_with(
+            "setpassword", "user1", "newpassword"
+        )
+
+    def test_worldgen(self):
+        self.pz.worldgen("status")
+        self.pz.command.assert_called_once_with("worldgen", "status")

--- a/zomboid_rcon/ZomboidRcon.py
+++ b/zomboid_rcon/ZomboidRcon.py
@@ -1,5 +1,7 @@
 """Zomboid RCON: https://github.com/jmwhitworth/zomboid_rcon"""
 
+import warnings
+
 from .BaseRconClient import BaseRconClient
 from .CommandResult import CommandResult
 
@@ -32,9 +34,30 @@ class ZomboidRcon(BaseRconClient):
             return self.command("additem", user, item, str(count))
         return self.command("additem", user, item)
 
+    def addkey(
+        self, user: str, key_id: str | int, name: str | None = None
+    ) -> CommandResult:
+        """Gives a key to a player.
+        /addkey "username" "keyId" "name"
+        Name is optional.
+        """
+        if name is not None:
+            return self.command("addkey", user, str(key_id), name)
+        return self.command("addkey", user, str(key_id))
+
+    def addsteamid(self, steam_id: str) -> CommandResult:
+        """Adds a Steam ID to the server's allowed Steam IDs.
+        /addSteamID "steamid"
+        """
+        return self.command("addSteamID", steam_id)
+
+    def addtosafehouse(self, *args: str) -> CommandResult:
+        """Runs Build 42's currently undocumented addtosafehouse command."""
+        return self.command("addtosafehouse", *args)
+
     def addvehicle(self, vehicle: str, user: str) -> CommandResult:
         """Spawns a vehicle near a player.
-        /addvehicle vehiclescript 'user'
+        /addvehicle vehiclescript "user or x,y,z"
         """
         return self.command("addvehicle", vehicle, user)
 
@@ -69,9 +92,15 @@ class ZomboidRcon(BaseRconClient):
         return self.command("changepwd", pwd, newPwd)
 
     def clear(self) -> CommandResult:
-        """Clears the server console.
-        /clear
+        """Runs the legacy Build 41 clear command.
+
+        This command is no longer listed by Build 42.
         """
+        warnings.warn(
+            "clear is not listed as a Build 42 command and may be rejected by the server",
+            UserWarning,
+            stacklevel=2,
+        )
         return self.command("clear")
 
     def createhorde(self, number: int, user: str | None = None) -> CommandResult:
@@ -82,6 +111,10 @@ class ZomboidRcon(BaseRconClient):
         if user is not None:
             return self.command("createhorde", str(number), user)
         return self.command("createhorde", str(number))
+
+    def createhorde2(self, *args: str) -> CommandResult:
+        """Runs Build 42's currently undocumented createhorde2 command."""
+        return self.command("createhorde2", *args)
 
     def godmode(self, user: str, value: bool = True) -> CommandResult:
         """Makes a player invincible.
@@ -95,11 +128,14 @@ class ZomboidRcon(BaseRconClient):
         """
         return self.command("gunshot")
 
-    def help(self) -> CommandResult:
+    def help(self, command: str | None = None) -> CommandResult:
         """Brings up the help menu.
-        /help
+        /help "command"
+        Command is optional and shows help for that specific command.
         Not to be confused with the commands available within zomboid_rcon. For a list of these commands see zomboid_rcon's Github repo: https://github.com/jmwhitworth/zomboid_rcon
         """
+        if command is not None:
+            return self.command("help", command)
         return self.command("help")
 
     def invisible(self, user: str, value: bool = True) -> CommandResult:
@@ -154,9 +190,15 @@ class ZomboidRcon(BaseRconClient):
         return self.command("reloadoptions")
 
     def replay(self, user: str, command: str, filename: str) -> CommandResult:
-        """Records and plays a replay for a moving player.
-        /replay "user" [-record | -play | -stop] "filename"
+        """Runs the legacy Build 41 replay command.
+
+        This command was removed in Build 42.
         """
+        warnings.warn(
+            "replay was removed in Build 42 and will be rejected by Build 42 servers",
+            UserWarning,
+            stacklevel=2,
+        )
         return self.command("replay", user, command, filename)
 
     def save(self) -> CommandResult:
@@ -224,6 +266,12 @@ class ZomboidRcon(BaseRconClient):
             return self.command("teleport", user, toUser)
         return self.command("teleport", user)
 
+    def teleportplayer(self, user: str, to_user: str) -> CommandResult:
+        """Teleports one player to another.
+        /teleportplayer "player1" "player2"
+        """
+        return self.command("teleportplayer", user, to_user)
+
     def teleportto(self, x: int, y: int, z: int) -> CommandResult:
         """Teleports to certain coordinates.
         /teleportto x,y,z
@@ -248,6 +296,18 @@ class ZomboidRcon(BaseRconClient):
         /addalltowhitelist
         """
         return self.command("addalltowhitelist")
+
+    def banip(self, ip: str) -> CommandResult:
+        """Bans an IP address.
+        /banip "IP"
+        """
+        return self.command("banip", ip)
+
+    def unbanip(self, ip: str) -> CommandResult:
+        """Unbans an IP address.
+        /unbanip "IP"
+        """
+        return self.command("unbanip", ip)
 
     def adduser(self, user: str, pwd: str) -> CommandResult:
         """Adds a new user to the whitelist.
@@ -315,17 +375,61 @@ class ZomboidRcon(BaseRconClient):
         """
         return self.command("removeadmin", user)
 
-    def kickuser(self, user: str) -> CommandResult:
+    def kickuser(self, user: str, reason: str | None = None) -> CommandResult:
         """Kicks a user from the server.
-        /kickuser "user"
+        /kickuser "user" -r "reason"
+        Reason is optional.
         """
+        if reason is not None:
+            return self.command("kickuser", user, "-r", reason)
         return self.command("kickuser", user)
+
+    def kickfromsafehouse(self, *args: str) -> CommandResult:
+        """Runs Build 42's currently undocumented kickfromsafehouse command."""
+        return self.command("kickfromsafehouse", *args)
+
+    def list(self, *args: str) -> CommandResult:
+        """Runs Build 42's currently undocumented list command."""
+        return self.command("list", *args)
 
     def players(self) -> CommandResult:
         """Lists all connected players.
         /players
         """
         return self.command("players")
+
+    def reloadalllua(self) -> CommandResult:
+        """Reloads all Lua scripts on the server.
+        /reloadalllua
+        """
+        return self.command("reloadalllua")
+
+    def remove(self, *args: str) -> CommandResult:
+        """Runs Build 42's currently undocumented remove command."""
+        return self.command("remove", *args)
+
+    def removeitem(self, item: str, count: int) -> CommandResult:
+        """Removes items of a type from the command issuer.
+        /removeitem "module.item" count
+        A count of zero removes all items of the specified type.
+        """
+        return self.command("removeitem", item, str(count))
+
+    def removemapsymbolsforuser(self, user: str) -> CommandResult:
+        """Removes all shared map symbols for a user.
+        /removemapsymbolsforuser "username"
+        """
+        return self.command("removemapsymbolsforuser", user)
+
+    def removesteamid(self, steam_id: str) -> CommandResult:
+        """Removes a Steam ID from the server's allowed Steam IDs.
+        /removeSteamID "steamid"
+        """
+        return self.command("removeSteamID", steam_id)
+
+    def removezombies(self, *args: str) -> CommandResult:
+        """Runs the currently undocumented removezombies command."""
+        return self.command("removezombies", *args)
 
     def servermsg(self, message: str) -> CommandResult:
         """Broadcast a message to all players.
@@ -339,12 +443,36 @@ class ZomboidRcon(BaseRconClient):
 
     def setaccesslevel(self, user: str, accesslevel: str) -> CommandResult:
         """Set the access/permission level of a player.
-        /setaccesslevel "user" "[admin | moderator | overseer | gm | observer]"
+        /setaccesslevel "user" "[user | priority | observer | gm | moderator | admin]"
         """
         return self.command("setaccesslevel", user, accesslevel)
+
+    def setpassword(self, user: str, new_password: str) -> CommandResult:
+        """Changes a user's password.
+        /setpassword "username" "newpassword"
+        """
+        return self.command("setpassword", user, new_password)
 
     def voiceban(self, user: str, ban: str) -> CommandResult:
         """Ban a user from using the voice feature.
         /voiceban "user" [-true | -false]
         """
         return self.command("voiceban", user, ban)
+
+    def worldgen(self, action: str) -> CommandResult:
+        """Controls Build 42's full world generator.
+        /worldgen [start | recheck | stop | status]
+        """
+        return self.command("worldgen", action)
+
+    def godmodeplayer(self, user: str, value: bool = True) -> CommandResult:
+        """Changes god mode for another player.
+        /godmodeplayer "username" -true|-false
+        """
+        return self.command("godmodeplayer", user, f"-{str(value).lower()}")
+
+    def invisibleplayer(self, user: str, value: bool = True) -> CommandResult:
+        """Changes invisibility for another player.
+        /invisibleplayer "username" -true|-false
+        """
+        return self.command("invisibleplayer", user, f"-{str(value).lower()}")

--- a/zomboid_rcon/__init__.py
+++ b/zomboid_rcon/__init__.py
@@ -21,4 +21,4 @@ class ZomboidRCON(ZomboidRcon):
 
 
 __title__ = "zomboid_rcon"
-__version__ = "2.1.0"
+__version__ = "2.2.0"


### PR DESCRIPTION
_Build 42 support_

### Added

- Full support for the admin and RCON commands documented for Project Zomboid Build 42.20.2
- New command methods for key management, Steam ID allowlisting, IP bans, player-specific admin actions, Lua reloading, item removal, map symbol removal, password changes, and world generation
- Passthrough methods for Build 42 commands whose arguments are not yet documented by Project Zomboid
- Optional command-specific help with `help("command")`
- Optional kick reasons with `kickuser("user", reason="reason")`

### Changed

- Updated `addvehicle()` to support either a player name or coordinates as its target
- Updated `setaccesslevel()` documentation with the Build 42 access levels
- Updated the command reference and test coverage for Build 42

### Deprecated

- `replay()` was removed from Project Zomboid Build 42 and now emits a warning while remaining available for Build 41 servers
- `clear()` is no longer listed as a Build 42 command and now emits a warning while remaining available for Build 41 servers